### PR TITLE
Parity config fix

### DIFF
--- a/parity.json
+++ b/parity.json
@@ -12,7 +12,8 @@
 				"ecip1010PauseTransition":0,
 				"ecip1010ContinueTransition":2000000,
 				"ecip1017EraRounds":2000000,
-				"bombDefuseTransition":0
+				"bombDefuseTransition":0,
+				"eip100bTransition": 100
 			}
 		}
 	},


### PR DESCRIPTION
Didn't enable EIP 100 functionality added in Atlantis